### PR TITLE
Fix pagination navigation bug

### DIFF
--- a/packages/app/src/components/layout/PaginationV2.jsx
+++ b/packages/app/src/components/layout/PaginationV2.jsx
@@ -1,10 +1,8 @@
 import NativeInput from "components/form/NativeInput";
 import { useCallback, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import isInputElement from "../../utilities/domUtils";
 
 const PaginationV2 = ({ page, total, onPageChange }) => {
-    const navigate = useNavigate();
     const previousEnabled = page + 1 > 1;
     const nextEnabled = page + 1 < total;
 
@@ -47,7 +45,11 @@ const PaginationV2 = ({ page, total, onPageChange }) => {
     return (
         <nav className="pagination is-centered is-rounded" role="navigation" aria-label="pagination">
             <button
-                onClick={() => navigate(`/auditlog?page=${page}`)}
+                type="button"
+                onClick={(ev) => {
+                    ev.preventDefault();
+                    onPreviousPageChange();
+                }}
                 className="pagination-previous"
                 tooltip="Previous [P]"
                 disabled={!previousEnabled}
@@ -73,7 +75,11 @@ const PaginationV2 = ({ page, total, onPageChange }) => {
                 </li>
             </ul>
             <button
-                onClick={() => navigate(`/auditlog?page=${page + 2}`)}
+                type="button"
+                onClick={(ev) => {
+                    ev.preventDefault();
+                    onNextPageChange();
+                }}
                 className="pagination-next"
                 tooltip="Next [N]"
                 disabled={!nextEnabled}


### PR DESCRIPTION
## Summary
- fix bug in PaginationV2 where the previous/next buttons always navigated to `/auditlog`
- rely on the `onPageChange` callback instead of hardcoded paths
- prevent default button behavior to avoid accidental form submissions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test` in `packages/app` *(fails: vitest not found)*
- `npm run lint` in `packages/app` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68633fa6b180832891e248f989ef3984